### PR TITLE
Add ability to use golang enums

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -740,7 +740,7 @@ func getColumnByType(engine *Engine, schema *tableSchema, field *reflect.StructF
 			checkError(err)
 			return "", false, "", false, structFields, nil, true
 		} else if kind == "string" {
-			getColumnByType(engine, schema, field, indexes, foreignKeys, typeAsString, definition, addNotNullIfNotSet, defaultValue, version, attributes, columnName, addDefaultNullIfNullable, err, isRequired)
+			return getColumnByType(engine, schema, field, indexes, foreignKeys, typeAsString, definition, addNotNullIfNotSet, defaultValue, version, attributes, columnName, addDefaultNullIfNullable, err, isRequired)
 		} else if kind == "ptr" {
 			subSchema := getTableSchema(engine.registry, field.Type.Elem())
 			if subSchema != nil {

--- a/schema.go
+++ b/schema.go
@@ -740,7 +740,7 @@ func getColumnByType(engine *Engine, schema *tableSchema, field *reflect.StructF
 			checkError(err)
 			return "", false, "", false, structFields, nil, true
 		} else if kind == "string" {
-			return getColumnByType(engine, schema, field, indexes, foreignKeys, typeAsString, definition, addNotNullIfNotSet, defaultValue, version, attributes, columnName, addDefaultNullIfNullable, err, isRequired)
+			return getColumnByType(engine, schema, field, indexes, foreignKeys, kind, definition, addNotNullIfNotSet, defaultValue, version, attributes, columnName, addDefaultNullIfNullable, err, isRequired)
 		} else if kind == "ptr" {
 			subSchema := getTableSchema(engine.registry, field.Type.Elem())
 			if subSchema != nil {

--- a/schema.go
+++ b/schema.go
@@ -739,8 +739,6 @@ func getColumnByType(engine *Engine, schema *tableSchema, field *reflect.StructF
 			structFields, err := checkStruct(schema, engine, field.Type, indexes, foreignKeys, field)
 			checkError(err)
 			return "", false, "", false, structFields, nil, true
-		} else if kind == "string" {
-			return getColumnByType(engine, schema, field, indexes, foreignKeys, kind, definition, addNotNullIfNotSet, defaultValue, version, attributes, columnName, addDefaultNullIfNullable, err, isRequired)
 		} else if kind == "ptr" {
 			subSchema := getTableSchema(engine.registry, field.Type.Elem())
 			if subSchema != nil {
@@ -750,8 +748,10 @@ func getColumnByType(engine *Engine, schema *tableSchema, field *reflect.StructF
 			} else {
 				definition = "json"
 			}
-		} else {
+		} else if kind == "slice" {
 			definition = "json"
+		} else {
+			return getColumnByType(engine, schema, field, indexes, foreignKeys, kind, definition, addNotNullIfNotSet, defaultValue, version, attributes, columnName, addDefaultNullIfNullable, err, isRequired)
 		}
 	}
 	return definition, addNotNullIfNotSet, defaultValue, addDefaultNullIfNullable, nil, nil, false


### PR DESCRIPTION
This is just a dirty POC to add ability to use golang enums in idiomatic way.
You don't suppose to merge this.
I just want to discuss about it.
You still will need to register enum values. It just enables users to use the original type instead of string.